### PR TITLE
plot-ready-metrics should return the same filename/file-url that is passed in

### DIFF
--- a/src/bcbio/variation/api/metrics.clj
+++ b/src/bcbio/variation/api/metrics.clj
@@ -84,7 +84,7 @@
         plot-metrics (if (nil? metrics) (available-metrics vcf-file) metrics)
         raw-metrics (clean-raw-metrics
                      (get-raw-metrics (map :id plot-metrics) vcf-file ref-file))]
-    {:filename vcf-file
+    {:filename in-vcf-file
      :created-on (java.util.Date.)
      :metrics (map #(merge % (prepare-plot-metrics (:id %) (get raw-metrics (:id %))))
                    (remove #(nil? (get raw-metrics (:id %))) plot-metrics))}))


### PR DESCRIPTION
Is it possible to have the `plot-ready-metrics` API function return the same file-url that is passed in?
Right now it's returning the name of the temporary file on the server disk, which feels like a leaking abstraction to me.
Source below for reference:

``` clojure
(defn plot-ready-metrics
  "Provide metrics for a VCF file ready for plotting and visualization."
  [in-vcf-file ref-file & {:keys [metrics creds cache-dir]}]
  (let [vcf-file (retrieve-file in-vcf-file creds cache-dir)
        plot-metrics (if (nil? metrics) (available-metrics vcf-file) metrics)
        raw-metrics (clean-raw-metrics
                     (get-raw-metrics (map :id plot-metrics) vcf-file ref-file))]
    {:filename vcf-file
     :created-on (java.util.Date.)
     :metrics (map #(merge % (prepare-plot-metrics (:id %) (get raw-metrics (:id %))))
                   (remove #(nil? (get raw-metrics (:id %))) plot-metrics))}))
```
